### PR TITLE
trigger 312 build

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/comm-feedstock/pr2/e9a22bc
+  - https://staging.continuum.io/prefect/fs/widgetsnbextension-feedstock/pr11/ed2510b
+  - https://staging.continuum.io/prefect/fs/jupyterlab_widgets-feedstock/pr5/e204ab0
+  - https://staging.continuum.io/prefect/fs/ipywidgets-feedstock/pr10/4b694e6

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/comm-feedstock/pr2/e9a22bc
-  - https://staging.continuum.io/prefect/fs/widgetsnbextension-feedstock/pr11/ed2510b
-  - https://staging.continuum.io/prefect/fs/jupyterlab_widgets-feedstock/pr5/e204ab0
-  - https://staging.continuum.io/prefect/fs/ipywidgets-feedstock/pr10/4b694e6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: d9dc4b3318f310e34c82951ea5d6683f67bed7def4b259fafbfe4f1beb1d8e5f
 
 build:
-  number: 9
+  number: 9 # trigger
 
 requirements:
   host:


### PR DESCRIPTION
Trigger build of the 3.12 variant, now that we have all the dependencies.

Not increasing the build number as skip-existing will skip other variants.